### PR TITLE
Fix to work under PHP 8.0.1

### DIFF
--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -355,6 +355,9 @@ class Shell extends CakeObject {
  */
 	public function hasMethod($name) {
 		try {
+			if(empty($name)) {
+				return false;
+			}
 			$method = new ReflectionMethod($this, $name);
 			if (!$method->isPublic() || substr($name, 0, 1) === '_') {
 				return false;


### PR DESCRIPTION
In PHP 8.0.1 (Ubuntu), it's not possible to execute any command as it would return this error:
Error: ReflectionMethod::__construct(): Argument #2 ($method) cannot be null when argument #1 ($objectOrMethod) is an object

Just add the fix to prevent empty value in hasMethod().

Taken from https://github.com/cakephp/cakephp/pull/15294