### PR TITLE
Don't use deprecated `Redis::delete()`

### DIFF
--- a/lib/Cake/Cache/Engine/RedisEngine.php
+++ b/lib/Cake/Cache/Engine/RedisEngine.php
@@ -173,7 +173,7 @@ class RedisEngine extends CacheEngine {
  * @return bool True if the value was successfully deleted, false if it didn't exist or couldn't be removed
  */
 	public function delete($key) {
-		return $this->_Redis->delete($key) > 0;
+		return $this->_Redis->del($key) > 0;
 	}
 
 /**


### PR DESCRIPTION
`Redis::del()` is the recommended alternative. 

This prevents PHP from warning about the deprecation.