### PR TITLE
Fix connection type to PDO

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -153,7 +153,7 @@ class DboSource extends DataSource {
 /**
  * A reference to the physical connection of this DataSource
  *
- * @var array
+ * @var PDO
  */
 	protected $_connection = null;
 


### PR DESCRIPTION
It has never been an array but always been a `PDO`.