### PR TITLE
Replace deprecated `Redis::getKeys()` call

### DIFF
--- a/lib/Cake/Cache/Engine/RedisEngine.php
+++ b/lib/Cake/Cache/Engine/RedisEngine.php
@@ -187,7 +187,7 @@ class RedisEngine extends CacheEngine {
 		if ($check) {
 			return true;
 		}
-		$keys = $this->_Redis->getKeys($this->settings['prefix'] . '*');
+		$keys = $this->_Redis->keys($this->settings['prefix'] . '*');
 		$this->_Redis->del($keys);
 
 		return true;


### PR DESCRIPTION
In newer versions it's completely removed, so it failed in our code base.