### PR TITLE
WI-4075 | changes to support PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"source": "https://github.com/diesocialisten/cakephp2"
 	},
 	"require": {
-		"php": ">=5.3.0,<8.1.0"
+		"php": ">=5.3.0,<8.2.0"
 	},
 	"suggest": {
 		"ext-openssl": "You need to install ext-openssl or ext-mcrypt to use AES-256 encryption",

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -344,7 +344,7 @@ class Mysql extends DboSource {
 		}
 		$table = $this->fullTableName($model);
 
-		$fields = false;
+		$fields = [];
 		$cols = $this->_execute('SHOW FULL COLUMNS FROM ' . $table);
 		if (!$cols) {
 			throw new CakeException(__d('cake_dev', 'Could not describe table for %s', $table));
@@ -361,7 +361,7 @@ class Mysql extends DboSource {
 				$fields[$column->Field]['unsigned'] = $this->_unsigned($column->Type);
 			}
 			if (in_array($fields[$column->Field]['type'], array('timestamp', 'datetime')) &&
-				in_array(strtoupper($column->Default), array('CURRENT_TIMESTAMP', 'CURRENT_TIMESTAMP()'))
+				in_array(strtoupper($column->Default ?? ''), array('CURRENT_TIMESTAMP', 'CURRENT_TIMESTAMP()'))
 			) {
 				$fields[$column->Field]['default'] = null;
 			}
@@ -918,7 +918,7 @@ class Mysql extends DboSource {
 		}
 		return $result;
 	}
-	
+
 	public function commit(): bool
 	{
 		try {


### PR DESCRIPTION
This PR should fix two issues that came up in the tests on PHP version 8.1.
- autovivification (creating array from false or null) error
- strtoupper Passing null to parameter ($string) of type string is deprecated