### PR TITLE
Allow `BackedEnum` in `Validation::notBlank()`

### DIFF
--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -70,7 +70,11 @@ class Validation {
  * @param string $check Value to check
  * @return bool Success
  */
-	public static function notBlank($check) {
+	public static function notBlank($check): bool {
+		if ($check instanceof BackedEnum) {
+			$check = $check->value;
+		}
+
 		if (empty($check) && !is_bool($check) && !is_numeric($check)) {
 			return false;
 		}


### PR DESCRIPTION
This allows the usage of backed enums in Model validations.