### PR TITLE
Fix deprecation warnings in PHP 8.3

### DIFF
--- a/lib/Cake/I18n/I18n.php
+++ b/lib/Cake/I18n/I18n.php
@@ -233,7 +233,8 @@ class I18n {
 		$_this->domain = $domain . '_' . $_this->l10n->lang;
 
 		if (!isset($_this->_domains[$domain][$_this->_lang])) {
-			$_this->_domains[$domain][$_this->_lang] = Cache::read($_this->domain, '_cake_core_');
+			$cached = Cache::read($_this->domain, '_cake_core_') ?: [];
+			$_this->_domains[$domain][$_this->_lang] = $cached;
 		}
 
 		if (!isset($_this->_domains[$domain][$_this->_lang][$_this->category])) {

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -513,7 +513,10 @@ class DboSource extends DataSource {
 			}
 			return $query;
 		} catch (PDOException $e) {
-			//this is adding a dynamic property querystring
+			if (!is_array($e->errorInfo)) {
+				$e->errorInfo = [];
+			}
+
 			if (isset($query->queryString)) {
 				$e->errorInfo["queryString"] = $query->queryString;
 			} else {

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -515,9 +515,9 @@ class DboSource extends DataSource {
 		} catch (PDOException $e) {
 			//this is adding a dynamic property querystring
 			if (isset($query->queryString)) {
-				$e->queryString = $query->queryString;
+				$e->errorInfo["queryString"] = $query->queryString;
 			} else {
-				$e->queryString = $sql;
+				$e->errorInfo["queryString"] = $sql;
 			}
 			throw $e;
 		}

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1229,6 +1229,7 @@ class Model extends CakeObject implements CakeEventListener {
 			}
 
 			if (!isset($this->data[$modelName])) {
+				$this->data = $this->data ?: [];
 				$this->data[$modelName] = array();
 			}
 


### PR DESCRIPTION
* Automatic conversion of `false` to arrays has been deprecated. 
* Dynamic properties have been deprecated. 

These cause deprecation warnings.