### PR TITLE
WI-7232 | Make sure `$this->request->data()` always contains an array

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -202,10 +202,10 @@ class CakeRequest implements ArrayAccess {
 			$this->data = array();
 		}
 
-		if ($isArray && isset($this->data['data'])) {
+		if ($isArray && isset($this->data['data']) && is_array($this->data['data'])) {
 			$data = $this->data['data'];
 			if (count($this->data) <= 1) {
-				$this->data = is_array($data) ? $data : $this->data;
+				$this->data = $data;
 			} else {
 				unset($this->data['data']);
 				$this->data = Hash::merge($this->data, $data);

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -205,7 +205,7 @@ class CakeRequest implements ArrayAccess {
 		if ($isArray && isset($this->data['data'])) {
 			$data = $this->data['data'];
 			if (count($this->data) <= 1) {
-				$this->data = $data;
+				$this->data = is_array($data) ? $data : $this->data;
 			} else {
 				unset($this->data['data']);
 				$this->data = Hash::merge($this->data, $data);


### PR DESCRIPTION
Before, if `$this->data["data"]` contains a string (and not an array), it would trip off methods like `$this->request->data("somefield", ...)`.