### PR TITLE
WI-7375 | Prevent $file->getMTime() from crashing

### DIFF
--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -284,7 +284,11 @@ class FileEngine extends CacheEngine {
 			}
 
 			if ($threshold) {
-				$mtime = $file->getMTime();
+				try {
+					$mtime = $file->getMTime();
+				} catch (RuntimeException $e) { // Race condition: The file was most likely deleted in the meantime
+					continue;
+				}
 
 				if ($mtime > $threshold) {
 					continue;


### PR DESCRIPTION
This code sometimes throws a `RuntimeException` with the message `SplFileInfo::getMTime(): stat failed for …`

According to docs, it should return `false` on error, but PHP is full of surprises… 
https://www.php.net/manual/en/splfileinfo.getmtime.php#:~:text=on%20success%2C%20or-,false%20on%20failure,-.

This fix assumes that the file was deleted by a different PHP process on the same machine, which can happen if there are many concurrent requests and short cache times.